### PR TITLE
Minify sys_specs.min.js further by adding alias for Number

### DIFF
--- a/sys_specs.min.js
+++ b/sys_specs.min.js
@@ -1,10 +1,10 @@
 function () {
 const s = #hs.sys.specs()
 if ("string" != typeof s) return s
-const [e, i, l, , c, , r, , t, u, , n, , a, , m, , , o, b, , , p, N] = s.split("\n"),
+const F = Number, [e, i, l, , c, , r, , t, u, , n, , a, , m, , , o, b, , , p, N] = s.split("\n"),
 [, d, x, f, h, g] = n.split("V"),
-[k, C] = o.slice(7).split("/").map(Number),
-[$, j] = b.slice(8).split("/").map(Number),
+[k, C] = o.slice(7).split("/").map(F),
+[$, j] = b.slice(8).split("/").map(F),
 [v, y] = c.split(" ")
-return {ok: !0, classArt: [e, i, l].join("\n"), user: v.slice(2, -1), class: y.slice(3, -2), tier: Number(r.slice(6)), hardlineCount: Number(t.slice(16)), nextHardline: Number(u.slice(20, -2)), classPoints: {architect: Number(d.slice(0, -16)), infiltrator: Number(x.slice(0, -19)), executive: Number(f.slice(0, -17)), junkrack: Number(h.slice(0, -17)), scavenger: Number(g.slice(0, -3))}, channelCount: Number(a.slice(15)), maxGC: m.slice(11), upgrades: {slots: k, slotsMax: C, loaded: $, loadedMax: j}, scripts: {publics: Number(p.slice(9)), slots: Number(N.slice(7))}}
+return {ok: !0, classArt: [e, i, l].join("\n"), user: v.slice(2, -1), class: y.slice(3, -2), tier: F(r.slice(6)), hardlineCount: F(t.slice(16)), nextHardline: F(u.slice(20, -2)), classPoints: {architect: F(d.slice(0, -16)), infiltrator: F(x.slice(0, -19)), executive: F(f.slice(0, -17)), junkrack: F(h.slice(0, -17)), scavenger: F(g.slice(0, -3))}, channelCount: F(a.slice(15)), maxGC: m.slice(11), upgrades: {slots: k, slotsMax: C, loaded: $, loadedMax: j}, scripts: {publics: F(p.slice(9)), slots: F(N.slice(7))}}
 }


### PR DESCRIPTION
This reduces the character count from 761 hmchars to 705 hmchars.

Using `F` as the alias to align with ECMA-262 `𝔽`.